### PR TITLE
Fix deprecation warnings and removals to allow the tests to run on Django 1.9.

### DIFF
--- a/contact_form/forms.py
+++ b/contact_form/forms.py
@@ -9,8 +9,8 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.template import loader
 from django.template import RequestContext
-from django.contrib.sites.models import RequestSite
 from django.contrib.sites.models import Site
+from django.contrib.sites.requests import RequestSite
 
 
 class ContactForm(forms.Form):

--- a/contact_form/runtests.py
+++ b/contact_form/runtests.py
@@ -21,7 +21,12 @@ sys.path.insert(0, CONTACT_FORM_DIR)
 # Minimum settings required for django-contact-form to work.
 SETTINGS_DICT = {
     'BASE_DIR': CONTACT_FORM_DIR,
-    'INSTALLED_APPS': ('contact_form', 'django.contrib.sites'),
+    'INSTALLED_APPS': (
+        'contact_form',
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sites',
+    ),
     'ROOT_URLCONF': 'contact_form.tests.urls',
     'DATABASES': {
         'default': {

--- a/contact_form/tests/test_views.py
+++ b/contact_form/tests/test_views.py
@@ -3,12 +3,13 @@ from django.core import mail
 from django.core.urlresolvers import reverse
 from django.test import RequestFactory
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from ..forms import ContactForm
 
 
+@override_settings(ROOT_URLCONF='contact_form.tests.test_urls')
 class ContactFormViewTests(TestCase):
-    urls = 'contact_form.tests.test_urls'
 
     def test_get(self):
         """


### PR DESCRIPTION
(some warnings remain, but will be easier addressed once Django 1.7 compatibility can be dropped)