### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,4 +7,4 @@ This application provides simple, extensible contact-form functionality
 for `Django <https://www.djangoproject.com/>`_ sites.
 
 Full documentation for all functionality is included and is also
-`available online <http://django-contact-form.readthedocs.org/>`_.
+`available online <https://django-contact-form.readthedocs.io/>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
