### PR TITLE
Django 1.10: fix template rendering to string

### DIFF
--- a/contact_form/forms.py
+++ b/contact_form/forms.py
@@ -10,7 +10,7 @@ from django.contrib.sites.models import Site
 from django.contrib.sites.requests import RequestSite
 from django.utils.translation import ugettext_lazy as _
 from django.core.mail import send_mail
-from django.template import RequestContext, loader
+from django.template import loader
 
 
 class ContactForm(forms.Form):
@@ -54,7 +54,8 @@ class ContactForm(forms.Form):
         else:
             template_name = self.template_name
         return loader.render_to_string(template_name,
-                                       self.get_context())
+                                       context=self.get_context(),
+                                       request=self.request)
 
     def subject(self):
         """
@@ -65,7 +66,8 @@ class ContactForm(forms.Form):
             callable(self.subject_template_name) \
             else self.subject_template_name
         subject = loader.render_to_string(template_name,
-                                          self.get_context())
+                                          context=self.get_context(),
+                                          request=self.request)
         return ''.join(subject.splitlines())
 
     def get_context(self):
@@ -79,10 +81,6 @@ class ContactForm(forms.Form):
           same names as their fields.
 
         * The current ``Site`` object, as the variable ``site``.
-
-        * Any additional variables added by context processors (this
-          will be a ``RequestContext``).
-
         """
         if not self.is_valid():
             raise ValueError(
@@ -92,9 +90,7 @@ class ContactForm(forms.Form):
             site = Site.objects.get_current()
         else:
             site = RequestSite(self.request)
-        return RequestContext(self.request,
-                              dict(self.cleaned_data,
-                                   site=site))
+        return dict(self.cleaned_data, site=site)
 
     def get_message_dict(self):
         """

--- a/contact_form/runtests.py
+++ b/contact_form/runtests.py
@@ -46,6 +46,7 @@ SETTINGS_DICT = {
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.request',
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',

--- a/contact_form/tests/templates/contact_form/test_template_request_context.html
+++ b/contact_form/tests/templates/contact_form/test_template_request_context.html
@@ -1,0 +1,1 @@
+{{ request.foo }}

--- a/contact_form/tests/test_forms.py
+++ b/contact_form/tests/test_forms.py
@@ -139,3 +139,24 @@ class ContactFormTests(TestCase):
 
         self.assertEqual(overridden_data,
                          form.get_message_dict())
+
+    def test_template_request_context(self):
+        """
+        When a template_name() method is defined, it is used and
+        preferred over a 'template_name' attribute.
+
+        """
+        class TemplateRequestContext(ContactForm):
+            template_name = 'contact_form/test_template_request_context.html'
+
+        request = self.request()
+        request.foo = 'bar'
+        form = TemplateRequestContext(request=request,
+                                      data=self.valid_data)
+        self.assertTrue(form.is_valid())
+
+        form.save()
+        self.assertEqual(1, len(mail.outbox))
+
+        message = mail.outbox[0]
+        self.assertTrue(request.foo in message.body)


### PR DESCRIPTION
Django 1.8 deprecated the `dictionary` and `context_instance` parameters
for `render_to_string()`, which have been removed in Django 1.10. This
means that instead of passing a `RequestContext` object to
`render_to_string()`, a dictionary needs to be passed in the `context`
parameter and a request in the `request` parameter.

Without this change, templates used in conjunction with
django-contact-form would have no means to access the `request` instance
in Django 1.10.