### PR TITLE
Compatibility: allow correct import of 'reverse'

### DIFF
--- a/contact_form/tests/test_views.py
+++ b/contact_form/tests/test_views.py
@@ -1,8 +1,11 @@
 from django.conf import settings
 from django.core import mail
-from django.core.urlresolvers import reverse
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # Django < 1.10
 
 from ..forms import ContactForm
 

--- a/contact_form/views.py
+++ b/contact_form/views.py
@@ -3,7 +3,10 @@ View which can render and send email from a contact form.
 
 """
 
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # Django < 1.10
 from django.views.generic.edit import FormView
 
 from .forms import ContactForm


### PR DESCRIPTION
This ensures that Django >= 1.10 import `reverse` from the correct place.  Although this is only removed in Django 2.0 it seems to cause unintended outcomes when apps combine old and new imports.

Specifically django-contrib-comments doesn't play well without this change on Pootle.

The `try` causes codecoverage reduction on Django 1.10, so the build fails.  Not 100% sure how you'd like that addressed.