### PR TITLE
Django 1.8 doesn't support Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ matrix:
      env: DJANGO_VERSION=1.9
    - python: "3.3"
      env: DJANGO_VERSION=1.10
+   - python: "3.6"
+     env: DJANGO_VERSION=1.8
 script:
  - make test


### PR DESCRIPTION
From Django 1.8 release notes "Django 1.8 requires Python 2.7, 3.2, 3.3, 3.4, or 3.5."