### PR TITLE
add Django 3.1 as supported version

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -11,7 +11,7 @@ you when installing, configuring or using django-contact-form.
 What versions of Django and Python are supported?
 -------------------------------------------------
 
-As of django-contact-form |release|, Django 2.2 and 3.0 are supported,
+As of django-contact-form |release|, Django 2.2, 3.0 and 3.1 are supported,
 on Python 3.5 (Django 2.2 only) 3.6, 3.7, and 3.8.
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -4,12 +4,12 @@
 Installation guide
 ==================
 
-The |release| release of django-contact-form supports Django 2.2 and
-3.0 on the following Python versions:
+The |release| release of django-contact-form supports Django 2.2,
+3.0 and 3.1 on the following Python versions:
 
 * Django 2.2 supports Python 3.5, 3.6, 3.7, and 3.8.
 
-* Django 3.0 supports Python 3.6, 3.7, and 3.8.
+* Django 3.0/3.1 supports Python 3.6, 3.7, and 3.8.
 
 
 Normal installation

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.1",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
@@ -34,6 +35,6 @@ setup(
     ],
     keywords=["django", "email", "contact-form"],
     python_requires=">=3.5",
-    install_requires=["Django>=2.2,<3.1"],
+    install_requires=["Django>=2.2,<3.2"],
     extras_require={"akismet": ["akismet"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist =
   {py35}-django{22}
-  {py36,py37,py38}-django{22,30}
+  {py36,py37,py38}-django{22,30,31}
   black
   docs
   flake8
@@ -100,11 +100,11 @@ deps =
   akismet
   coverage
   django22: Django>=2.2,<3.0
-  django30: Django>=3.0,<3.1
+  django30: Django>=3.0,<3.2
 
 [travis]
 python =
   3.5: py35
   3.6: py36
-  3.7: py37, 
+  3.7: py37,
   3.8: py38, black, docs, flake8, isort, mypy, spelling


### PR DESCRIPTION
Hello there, 

It will be wonderful if we allow Django 3.1 in django-contact-form too.

I have created a pull request, just in case it can be used.

Many thanks, T

