### PR TITLE
Rename ContactForm.get_context() to get_message_context().

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -11,7 +11,7 @@ you when installing, configuring or using django-contact-form.
 What versions of Django and Python are supported?
 -------------------------------------------------
 
-As of django-contact-form |release|, Django 2.2, 3.1, and 3.2 are
+As of django-contact-form |release|, Django 2.2, 3.1, 3.2, and 4.0 are
 supported, on Python 3.6, 3.7, 3.8, and 3.9.
 
 

--- a/docs/forms.rst
+++ b/docs/forms.rst
@@ -130,7 +130,7 @@ The ContactForm class
 
        :rtype: dict
 
-    .. method:: get_context
+    .. method:: get_message_context
 
        For methods which render portions of the message using
        templates (by default, :meth:`message` and :meth:`subject`),

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@ Installation guide
 ==================
 
 The |release| release of django-contact-form supports Django 2.2, 3.1,
-and 3.2 on Python 3.6, 3.7, 3.8, and 3.9.
+3.2, and 4.0 on Python 3.6, 3.7, 3.8, and 3.9.
 
 
 Normal installation

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.1",
         "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/src/contact_form/forms.py
+++ b/src/contact_form/forms.py
@@ -73,7 +73,7 @@ class ContactForm(forms.Form):
             self.template_name() if callable(self.template_name) else self.template_name
         )
         return loader.render_to_string(
-            template_name, self.get_context(), request=self.request
+            template_name, self.get_message_context(), request=self.request
         )
 
     def subject(self) -> str:
@@ -87,11 +87,11 @@ class ContactForm(forms.Form):
             else self.subject_template_name
         )
         subject = loader.render_to_string(
-            template_name, self.get_context(), request=self.request
+            template_name, self.get_message_context(), request=self.request
         )
         return "".join(subject.splitlines())
 
-    def get_context(self) -> StringKeyedDict:
+    def get_message_context(self) -> StringKeyedDict:
         """
         Return the context used to render the templates for the email
         subject and body.

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -35,7 +35,7 @@ class ContactFormTests(TestCase):
         data = {"name": "Test", "body": "Test message"}
         form = ContactForm(request=self.request(), data=data)
         self.assertRaises(ValueError, form.get_message_dict)
-        self.assertRaises(ValueError, form.get_context)
+        self.assertRaises(ValueError, form.get_message_context)
 
     def test_send(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@
 [tox]
 envlist =
   py{36,37,38,39}-django{22,31,32}
+  py{38,39}-django40
   black
   check-description
   check-manifest
@@ -81,6 +82,7 @@ deps =
   django22: Django>=2.2,<3.0
   django31: Django>=3.1,<3.2
   django32: Django>=3.2,<4.0
+  django40: Django>=4.0b1,<4.1
 passenv =
   PYTHON_AKISMET_API_KEY
   PYTHON_AKISMET_BLOG_URL


### PR DESCRIPTION
`Form.get_context()` was added in [Django 4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#template-based-form-rendering).

I'm not sure if such a breaking change is acceptable.